### PR TITLE
reset password by admin

### DIFF
--- a/Client-React/app/src/pages/AdminPage.jsx
+++ b/Client-React/app/src/pages/AdminPage.jsx
@@ -290,6 +290,37 @@ const AdminPage = () => {
     }
   };
 
+  // Send reset link
+  const handleSendResetLink = async (email) => {
+    try {
+      await axios.post(`${API_URL}/user/admin-send-reset-link`, { email });
+      alert("קישור לאיפוס סיסמה נשלח למייל של המשתמש.");
+    } catch (err) {
+      alert("אירעה שגיאה בשליחת הקישור.");
+    }
+  };
+
+  // Reset password by admin
+  const handleResetPasswordByAdmin = async (userId, newPassword) => {
+    if (!newPassword) {
+      alert("אנא הזן סיסמה חדשה.");
+      return;
+    }
+  
+    if (!window.confirm("האם לאפס את הסיסמה של המשתמש?")) return;
+  
+    try {
+      await axios.post(`${API_URL}/user/admin-reset-password`, {
+        userId,
+        newPassword,
+      }, { withCredentials: true });
+  
+      alert("הסיסמה אופסה בהצלחה.");
+    } catch (err) {
+      alert("שגיאה באיפוס הסיסמה.");
+    }
+  };
+
   // Cancel edit
   const handleEditCancel = () => setEditId(null);
 
@@ -464,6 +495,28 @@ const AdminPage = () => {
                         </ActionButton>
                       </>
                     )}
+
+                     {/* הצגת כפתורי איפוס סיסמה תמיד, גם בעריכה */}
+                     <div style={{ marginTop: "0.5rem" }}>
+                      <ActionButton onClick={() => handleSendResetLink(u.email)}>
+                        שליחת קישור איפוס סיסמא
+                      </ActionButton>
+                    </div>
+
+                    <div style={{ marginTop: "0.5rem" }}>
+                      <input
+                        type="password"
+                        placeholder="סיסמה חדשה"
+                        onChange={(e) => u.newPassword = e.target.value}
+                        style={{ padding: "0.3rem", marginRight: "0.5rem" }}
+                      />
+                      <ActionButton
+                        onClick={() => handleResetPasswordByAdmin(u._id, u.newPassword)}
+                        color="#17a2b8"
+                      >
+                        אפס סיסמה ידנית
+                      </ActionButton>
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/Client-React/app/src/pages/ForgotPassword.jsx
+++ b/Client-React/app/src/pages/ForgotPassword.jsx
@@ -110,7 +110,7 @@ export default function ForgotPassword() {
       setError("");
       setIsLoading(true);
       try {
-        const res = await fetch(`${process.env.REACT_APP_API_URL}/user/forgot-password`, {
+        const res = await fetch(`${process.env.REACT_APP_API_URL || "http://localhost:5000"}/user/forgot-password`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ email: values.email }),

--- a/Client-React/app/src/pages/LoginPage.jsx
+++ b/Client-React/app/src/pages/LoginPage.jsx
@@ -66,7 +66,7 @@ const LoginPage = () => {
             try {
                 setLoading(true);
 
-                const { data } = await axios.post(`${process.env.REACT_APP_API_URL}/user/login`, {
+                const { data } = await axios.post(`${process.env.REACT_APP_API_URL } || http://localhost:5000/user/login`, {
                     ...values,
                     captchaToken
                 });

--- a/Client-React/app/src/pages/ResetPassword.jsx
+++ b/Client-React/app/src/pages/ResetPassword.jsx
@@ -29,7 +29,7 @@ export default function ResetPassword() {
     setError("");
 
     try {
-      const res = await fetch(`${process.env.REACT_APP_API_URL || "http://localhost:5000"}/user/reset-password`, {
+      const res = await fetch(`${process.env.REACT_APP_API_URL} || http://localhost:5000/user/reset-password`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ token, password }),

--- a/Server-node/middleware/requireRole.js
+++ b/Server-node/middleware/requireRole.js
@@ -1,13 +1,15 @@
 //requireRole.js
 
-module.exports = function requireRole(...allowedRoles) {
+module.exports = function requireRole(allowedRoles) {
     return (req, res, next) => {
+        console.log(req.user);
         if (!req.user) {
             return res.status(401).json({ message: 'Not authenticated' });
         }
         if (!allowedRoles.includes(req.user.role)) {
             return res.status(403).json({ message: 'Forbidden: insufficient role' });
         }
+        
         next();
     };
 };


### PR DESCRIPTION
## Summary by Sourcery

Enable admins to reset user passwords manually or by sending email reset links and ensure client API requests default to localhost when environment variable is missing

New Features:
- Add admin UI and API endpoint for sending password reset links via email
- Add admin UI and API endpoint for manually resetting user passwords

Enhancements:
- Update requireRole middleware to accept an array of roles and log user info
- Add fallback to localhost for API_URL in client fetch/axios calls